### PR TITLE
ccy.y: Avoid a trivial Bison extension so standard yacc can be used

### DIFF
--- a/ccy.y
+++ b/ccy.y
@@ -21,7 +21,7 @@ extern int yyerror(const char *);
 %%                              // Rules section.
 
 input:
-  %empty
+  /* empty */
 | input line
 ;
 


### PR DESCRIPTION
Use an `/* empty */` comment instead of Bison's non-standard `%empty` directive.

This change allows building on systems with non-Bison yacc (like BSDs).

Thanks!