### PR TITLE
cadet.c: include <err.h>

### DIFF
--- a/cadet.c
+++ b/cadet.c
@@ -1,6 +1,7 @@
 // cadet.c --- Space Cadet (aka new) keyboard translation
 
 #include <stdint.h>
+#include <err.h>
 
 #include "lmch.h"
 #include "cadet.h"


### PR DESCRIPTION
This header is (currently) needed because `errx` is used in `cadet_init`.