### PR TITLE
ucfg.c: fix call to warnx

### DIFF
--- a/ucfg.c
+++ b/ucfg.c
@@ -84,7 +84,7 @@ ucfg_handler(void *user, const char *section, const char *name, const char *valu
 	if (INIHEQ("kbd", "type")) {
 		     if (streq("knight", cfg->kbd_type)) kbd_type = 0;
 		else if (streq("cadet", cfg->kbd_type))  kbd_type = 1;
-		else warnx(1, "unknown keyboard type: %s", cfg->kbd_type);
+		else warnx("unknown keyboard type: %s", cfg->kbd_type);
 	}
 
 	return 1;


### PR DESCRIPTION
This fixes a call to `warnx` in ucfg.c.

The messages for unknown trace levels and facilities use `warnx`, so I'm thinking a `warnx` really was intended here as well (as opposed to, say, `errx`).

(I could be wrong about the intention here, so perhaps this should be fixed in a different way.)